### PR TITLE
Case insensitive files

### DIFF
--- a/bin/epg-prep
+++ b/bin/epg-prep
@@ -3,28 +3,58 @@ var gulp = require('gulp');
 var resize = require('gulp-image-resize');
 var parallel = require('concurrent-transform');
 var debug = require('gulp-debug');
+var del = require('del');
 var rename = require('gulp-rename');
 var CORES = require('os').cpus().length;
 var path = require('path');
 var photoLocation = path.resolve(process.argv[process.argv.length - 1]);
 console.log('Preparing: ' + photoLocation);
 
-gulp.task('previews', function() {
+// Makes sure all the images have the .jpg extension. Does so by copying them
+// into a /tmp folder and changing the extension.
+gulp.task('canonicalize1', function() {
   return gulp.src([photoLocation + '/*.jpg', photoLocation + '/*.JPG', photoLocation + '/*.jpeg', photoLocation + '/*.JPEG'])
-    .pipe(parallel(resize({width:1500, quality: 0.5}), CORES))
-    //.pipe(rename(function(path) {path.basename += '_preview'}))
-    .pipe(gulp.dest(photoLocation + '/previews'))
-    .pipe(debug({title: 'Created'}));
+  .pipe(rename(function(path) {
+    path.extname = ".jpg"
+  }))
+  .pipe(gulp.dest(photoLocation + '/tmp'));
+});
+
+// Removes the original files from which the tmp files were copied.
+gulp.task('del-orig', ['canonicalize1'], function(){
+  return del([photoLocation + '/*.jpg', photoLocation + '/*.JPG', photoLocation + '/*.jpeg', photoLocation + '/*.JPEG'], {force: true});
+});
+
+// Copies back the newly created canocicalized files.
+gulp.task('copy-back', ['del-orig'], function(){
+  return gulp.src([photoLocation + '/tmp/*.jpg'])
+  .pipe(gulp.dest(photoLocation));
+})
+
+// Removes the tmp directory.
+gulp.task('cleanup', ['copy-back'], function(){
+  return del([photoLocation + '/tmp'], {force: true});
+});
+
+gulp.task('previews', ['canonicalize'], function() {
+  return gulp.src([photoLocation + '/*.jpg', photoLocation + '/*.JPG', photoLocation + '/*.jpeg', photoLocation + '/*.JPEG'])
+  .pipe(parallel(resize({width:1500, quality: 0.5}), CORES))
+  .pipe(rename(function(path) {
+    path.extname = ".jpg"
+  }))
+  .pipe(gulp.dest(photoLocation + '/previews'))
+  .pipe(debug({title: 'Created'}));
 });
 
 gulp.task('thumbnails', ['previews'], function() {
   return gulp.src([photoLocation + '/previews/*.jpg', photoLocation + '/previews/*.JPG', photoLocation + '/previews/*.jpeg', photoLocation + '/previews/*.JPEG'])
-    .pipe(parallel(resize({width:200}), CORES))
-    //.pipe(rename(function(path) {path.basename += '_thumb'}))
-    .pipe(gulp.dest(photoLocation + '/thumbs'))
-    .pipe(debug({title: 'Created'}));
+  .pipe(parallel(resize({width:200}), CORES))
+  //.pipe(rename(function(path) {path.basename += '_thumb'}))
+  .pipe(gulp.dest(photoLocation + '/thumbs'))
+  .pipe(debug({title: 'Created'}));
 });
 
-gulp.task('prep', ['previews', 'thumbnails']);
+gulp.task('canonicalize', ['canonicalize1', 'del-orig', 'copy-back', 'cleanup']);
+gulp.task('prep', ['canonicalize', 'previews', 'thumbnails']);
 
 gulp.start('prep');

--- a/bin/epg-prep
+++ b/bin/epg-prep
@@ -10,7 +10,7 @@ var photoLocation = path.resolve(process.argv[process.argv.length - 1]);
 console.log('Preparing: ' + photoLocation);
 
 gulp.task('previews', function() {
-  return gulp.src(photoLocation + '/*.jpg')
+  return gulp.src([photoLocation + '/*.jpg', photoLocation + '/*.JPG', photoLocation + '/*.jpeg', photoLocation + '/*.JPEG'])
     .pipe(parallel(resize({width:1500, quality: 0.5}), CORES))
     //.pipe(rename(function(path) {path.basename += '_preview'}))
     .pipe(gulp.dest(photoLocation + '/previews'))
@@ -18,7 +18,7 @@ gulp.task('previews', function() {
 });
 
 gulp.task('thumbnails', ['previews'], function() {
-  return gulp.src(photoLocation + '/previews/*.jpg')
+  return gulp.src([photoLocation + '/previews/*.jpg', photoLocation + '/previews/*.JPG', photoLocation + '/previews/*.jpeg', photoLocation + '/previews/*.JPEG'])
     .pipe(parallel(resize({width:200}), CORES))
     //.pipe(rename(function(path) {path.basename += '_thumb'}))
     .pipe(gulp.dest(photoLocation + '/thumbs'))

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "concurrent-transform": "^1.0.0",
+    "del": "^2.2.2",
     "gulp": "^3.9.1",
     "gulp-debug": "^2.1.2",
     "gulp-image-resize": "^0.8.0",


### PR DESCRIPTION
Hi,

I was using this tool in combination with your gallery. I noticed that some files with `JPG` extensions were not handled or recognised by your tools so I patched that in.

I'm no Gulp expert so there might be better ways, but I figured I'd show you how I did it.

1. Copy all files to `./tmp` directory with `.jpg` extension.
2. Delete all the original files.
3. Copy the files back to `./`.
4. Delete `./tmp` directory

Kind regards,
Christophe De Troyer

PS: I am no expert, so please comment on possible improvements or blatant mistakes.